### PR TITLE
Add support for string-based paths to `has`, `get` and `set`

### DIFF
--- a/index.js
+++ b/index.js
@@ -8,6 +8,11 @@ function Traverse (obj) {
 
 Traverse.prototype.get = function (ps) {
     var node = this.value;
+
+    if (typeof ps === 'string') {
+        ps = ps ? ps.split('.') : [];
+    }
+
     for (var i = 0; i < ps.length; i ++) {
         var key = ps[i];
         if (!hasOwnProperty.call(node, key)) {
@@ -21,6 +26,11 @@ Traverse.prototype.get = function (ps) {
 
 Traverse.prototype.has = function (ps) {
     var node = this.value;
+
+    if (typeof ps === 'string') {
+        ps = ps ? ps.split('.') : [];
+    }
+
     for (var i = 0; i < ps.length; i ++) {
         var key = ps[i];
         if (!hasOwnProperty.call(node, key)) {
@@ -33,6 +43,15 @@ Traverse.prototype.has = function (ps) {
 
 Traverse.prototype.set = function (ps, value) {
     var node = this.value;
+
+    if (typeof ps === 'string') {
+        ps = ps ? ps.split('.') : [];
+    }
+
+    if (!ps.length) {
+        return;
+    }
+
     for (var i = 0; i < ps.length - 1; i ++) {
         var key = ps[i];
         if (!hasOwnProperty.call(node, key)) node[key] = {};

--- a/test/get.js
+++ b/test/get.js
@@ -1,0 +1,22 @@
+var test = require('tape');
+var traverse = require('../');
+
+test('get', function (t) {
+    var obj = { a : 2, b : [ 4, 5, { c : 6 } ] };
+    
+    t.equal(traverse(obj).get([ 'b', 2, 'c' ]), 6)
+    t.equal(traverse(obj).get([ 'b', 2, 'c', 0 ]), undefined)
+    t.equal(traverse(obj).get([ 'b', 2, 'd' ]), undefined)
+    t.equal(traverse(obj).get([]), obj)
+    t.equal(traverse(obj).get([ 'a' ]), 2)
+    t.equal(traverse(obj).get([ 'a', 2 ]), undefined)
+    
+    t.equal(traverse(obj).get( 'b.2.c' ), 6)
+    t.equal(traverse(obj).get( 'b.2.c.0' ), undefined)
+    t.equal(traverse(obj).get( 'b.2.d' ), undefined)
+    t.equal(traverse(obj).get(''), obj)
+    t.equal(traverse(obj).get( 'a' ), 2)
+    t.equal(traverse(obj).get( 'a.2' ), undefined)
+    
+    t.end();
+});

--- a/test/has.js
+++ b/test/has.js
@@ -11,5 +11,12 @@ test('has', function (t) {
     t.equal(traverse(obj).has([ 'a' ]), true)
     t.equal(traverse(obj).has([ 'a', 2 ]), false)
     
+    t.equal(traverse(obj).has('b.2.c'), true)
+    t.equal(traverse(obj).has('b.2.c.0'), false)
+    t.equal(traverse(obj).has('b.2.d'), false)
+    t.equal(traverse(obj).has(''), true)
+    t.equal(traverse(obj).has('a'), true)
+    t.equal(traverse(obj).has('a.2'), false)
+    
     t.end();
 });

--- a/test/set.js
+++ b/test/set.js
@@ -1,0 +1,34 @@
+var test = require('tape');
+var traverse = require('../');
+
+test('get', function (t) {
+    var obj = { a : 2, b : [ 4, 5, { c : 6 } ] };
+    
+    traverse(obj).set([ 'b', 2, 'c' ], 7)
+    t.equal(traverse(obj).get([ 'b', 2, 'c' ]), 7)
+    traverse(obj).set([ 'b', 2, 'c', 0 ], 8)
+    t.equal(traverse(obj).get([ 'b', 2, 'c', 0 ]), undefined)
+    traverse(obj).set([ 'b', 2, 'd' ], 9)
+    t.equal(traverse(obj).get([ 'b', 2, 'd' ]), 9)
+    traverse(obj).set([], false)
+    t.equal(traverse(obj).get([]), obj)
+    traverse(obj).set([ 'a' ], 10)
+    t.equal(traverse(obj).get([ 'a' ]), 10)
+    traverse(obj).set([ 'a', 2 ], 11)
+    t.equal(traverse(obj).get([ 'a', 2 ]), undefined)
+    
+    traverse(obj).set('b.2.c', 7)
+    t.equal(traverse(obj).get('b.2.c'), 7)
+    traverse(obj).set('b.2.c.0', 8)
+    t.equal(traverse(obj).get('b.2.c.0'), undefined)
+    traverse(obj).set('b.2.d', 9)
+    t.equal(traverse(obj).get('b.2.d'), 9)
+    traverse(obj).set('', false)
+    t.equal(traverse(obj).get(''), obj)
+    traverse(obj).set('a', 10)
+    t.equal(traverse(obj).get('a'), 10)
+    traverse(obj).set('a.2', 11)
+    t.equal(traverse(obj).get('a.2'), undefined)
+    
+    t.end();
+});


### PR DESCRIPTION
Minor note:

Since `traverse.set` is a noop for an invalid path,
```javascript
traverse.set({foo: 2}, ['foo', 2, 'bar'], 'baz')
```
`traverse.set({foo: 2}, [], 'bar')` is a noop.