### PR TITLE
feat(#30): string based paths

### DIFF
--- a/index.js
+++ b/index.js
@@ -4,10 +4,14 @@ var traverse = module.exports = function (obj) {
 
 function Traverse (obj) {
     this.value = obj;
+    this.pathSeparator = '.'
 }
 
 Traverse.prototype.get = function (ps) {
     var node = this.value;
+    if (typeof ps === 'string') { 
+        ps = ps.split(this.pathSeparator)
+    }
     for (var i = 0; i < ps.length; i ++) {
         var key = ps[i];
         if (!node || !hasOwnProperty.call(node, key)) {
@@ -21,6 +25,9 @@ Traverse.prototype.get = function (ps) {
 
 Traverse.prototype.has = function (ps) {
     var node = this.value;
+    if (typeof ps === 'string') { 
+        ps = ps.split(this.pathSeparator)
+    }
     for (var i = 0; i < ps.length; i ++) {
         var key = ps[i];
         if (!node || !hasOwnProperty.call(node, key)) {
@@ -33,6 +40,9 @@ Traverse.prototype.has = function (ps) {
 
 Traverse.prototype.set = function (ps, value) {
     var node = this.value;
+    if (typeof ps === 'string') { 
+        ps = ps.split(this.pathSeparator)
+    }
     for (var i = 0; i < ps.length - 1; i ++) {
         var key = ps[i];
         if (!hasOwnProperty.call(node, key)) node[key] = {};

--- a/readme.markdown
+++ b/readme.markdown
@@ -112,15 +112,19 @@ Create a deep clone of the object.
 
 ## .get(path)
 
-Get the element at the array `path`.
+Get the element at the array or string `path`.
 
 ## .set(path, value)
 
-Set the element at the array `path` to `value`.
+Set the element at the array or string `path` to `value`.
 
 ## .has(path)
 
-Return whether the element at the array `path` exists.
+Return whether the element at the array or string `path` exists.
+
+## .pathSeparator = `.`
+
+Path separator for string expressions.
 
 # context
 

--- a/test/has.js
+++ b/test/has.js
@@ -10,6 +10,8 @@ test('has', function (t) {
     t.equal(traverse(obj).has([]), true)
     t.equal(traverse(obj).has([ 'a' ]), true)
     t.equal(traverse(obj).has([ 'a', 2 ]), false)
+    t.equal(traverse(obj).has('a'), true)
+    t.equal(traverse(obj).has('b.2.c'), true)
     
     t.end();
 });


### PR DESCRIPTION
#30 Tiny add-on to support string based paths, with customizable path separator. 
It cannot process path which points to end values due type casting cannot be applied.

Ideally, this feature should be covered in the future with more versatility based on JSONPath.