### PR TITLE
Async.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+**/.DS_Store
+node_modules

--- a/package.json
+++ b/package.json
@@ -1,46 +1,64 @@
 {
-    "name" : "traverse",
-    "version" : "0.6.6",
-    "description" : "traverse and transform objects by visiting every node on a recursive walk",
-    "main" : "index.js",
-    "directories" : {
-        "example" : "example",
-        "test" : "test"
-    },
-    "devDependencies" : {
-        "tape" : "~1.0.4"
-    },
-    "scripts" : {
-        "test" : "tape test/*.js"
-    },
-    "testling" : {
-        "files" : "test/*.js",
-        "browsers" : {
-            "iexplore" : [ "6.0", "7.0", "8.0", "9.0" ],
-            "chrome" : [ "10.0", "20.0" ],
-            "firefox" : [ "10.0", "15.0" ],
-            "safari" : [ "5.1" ],
-            "opera" : [ "12.0" ]
-        }
-    },
-    "repository" : {
-        "type" : "git",
-        "url" : "git://github.com/substack/js-traverse.git"
-    },
-    "homepage" : "https://github.com/substack/js-traverse",
-    "keywords" : [
-        "traverse",
-        "walk",
-        "recursive",
-        "map",
-        "forEach",
-        "deep",
-        "clone"
-    ],
-    "author" : {
-        "name" : "James Halliday",
-        "email" : "mail@substack.net",
-        "url" : "http://substack.net"
-    },
-    "license" : "MIT"
+  "name": "traverse",
+  "version": "0.6.6",
+  "description": "traverse and transform objects by visiting every node on a recursive walk",
+  "main": "index.js",
+  "directories": {
+    "example": "example",
+    "test": "test"
+  },
+  "devDependencies": {
+    "tape": "~1.0.4"
+  },
+  "scripts": {
+    "test": "tape test/*.js"
+  },
+  "testling": {
+    "files": "test/*.js",
+    "browsers": {
+      "iexplore": [
+        "6.0",
+        "7.0",
+        "8.0",
+        "9.0"
+      ],
+      "chrome": [
+        "10.0",
+        "20.0"
+      ],
+      "firefox": [
+        "10.0",
+        "15.0"
+      ],
+      "safari": [
+        "5.1"
+      ],
+      "opera": [
+        "12.0"
+      ]
+    }
+  },
+  "repository": {
+    "type": "git",
+    "url": "git://github.com/substack/js-traverse.git"
+  },
+  "homepage": "https://github.com/substack/js-traverse",
+  "keywords": [
+    "traverse",
+    "walk",
+    "recursive",
+    "map",
+    "forEach",
+    "deep",
+    "clone"
+  ],
+  "author": {
+    "name": "James Halliday",
+    "email": "mail@substack.net",
+    "url": "http://substack.net"
+  },
+  "license": "MIT",
+  "dependencies": {
+    "async": "^1.4.0"
+  }
 }

--- a/test/async-clone.js
+++ b/test/async-clone.js
@@ -1,0 +1,19 @@
+var test = require('tape');
+var traverse = require('../');
+var traverseAsync = traverse.async;
+var deepEqual = require('./lib/deep_equal');
+var util = require('util');
+
+test('async nodes', function (t) {
+    t.plan(2);
+
+    var obj = { x : { y : 2 }, a: 4 };
+    var expected = { x : { y : 2 }, a: 4 };
+
+    var sync = traverse(obj).clone();
+    t.deepEqual(sync, expected);
+
+    traverseAsync(obj).clone(function (err, cloned) {
+        t.deepEqual(cloned, expected);
+    });
+});

--- a/test/async-each.js
+++ b/test/async-each.js
@@ -1,0 +1,51 @@
+var test = require('tape');
+var traverse = require('../').async;
+var deepEqual = require('./lib/deep_equal');
+var util = require('util');
+
+test('async each', function (t) {
+    t.plan(1);
+
+    var obj = { x : 3 };
+    traverse(obj).forEach(function (x, cb) {
+        cb();
+    }, function (err, newObj) {
+        t.pass();
+    });
+});
+
+test('async each context', function (t) {
+    t.plan(1);
+
+    var obj = { x: { y: 3 }};
+    traverse(obj).forEach(function (x, cb) {
+        console.log(this.node);
+        console.log(this.path);
+        console.log(this.key);
+        console.log(this.isRoot);
+        console.log(this.notRoot);
+        console.log(this.isLeaf);
+        console.log(this.notLeaf);
+        console.log(this.level);
+        console.log(this.circular);
+        cb();
+    }, function (err, newObj) {
+        t.pass();
+    });
+});
+
+test('async each update', function (t) {
+    t.plan(1);
+
+    var obj = { x: { y: 3 }};
+    traverse(obj).forEach(function (x, cb) {
+        if (this.key === 'y') {
+            this.update({z: 0});
+        }
+        cb();
+    }, function (err, newObj) {
+        t.pass();
+        console.log(JSON.stringify(obj, null, '  '));
+        console.log(JSON.stringify(newObj, null, '  '));
+    });
+});

--- a/test/async-map.js
+++ b/test/async-map.js
@@ -1,0 +1,32 @@
+var test = require('tape');
+var traverse = require('../').async;
+var deepEqual = require('./lib/deep_equal');
+var util = require('util');
+
+test('async map', function (t) {
+    t.plan(1);
+
+    var obj = { x : 3 };
+    traverse(obj).map(function (x, cb) {
+        this.update('a');
+        cb();
+    }, function (err, newObj) {
+        t.pass();
+    });
+});
+
+test('async map update', function (t) {
+    t.plan(1);
+
+    var obj = { x: { y: 3 }};
+    traverse(obj).map(function (x, cb) {
+        if (this.key === 'y') {
+            this.update({z: 0});
+        }
+        cb();
+    }, function (err, newObj) {
+        t.pass();
+        console.log(JSON.stringify(obj, null, '  '));
+        console.log(JSON.stringify(newObj, null, '  '));
+    });
+});

--- a/test/async-nodes.js
+++ b/test/async-nodes.js
@@ -1,0 +1,19 @@
+var test = require('tape');
+var traverse = require('../');
+var traverseAsync = traverse.async;
+var deepEqual = require('./lib/deep_equal');
+var util = require('util');
+
+test('async nodes', function (t) {
+    t.plan(2);
+
+    var obj = { x : { y : 2 }, a: 4 };
+
+    var expected = [ { x: { y: 2 }, a: 4 }, { y: 2 }, 2, 4 ];
+    var sync = traverse(obj).nodes();
+    t.deepEqual(sync, expected);
+
+    traverseAsync(obj).nodes(function (err, nodes) {
+        t.deepEqual(nodes, expected);
+    });
+});

--- a/test/async-paths.js
+++ b/test/async-paths.js
@@ -1,0 +1,19 @@
+var test = require('tape');
+var traverse = require('../');
+var traverseAsync = traverse.async;
+var deepEqual = require('./lib/deep_equal');
+var util = require('util');
+
+test('async paths', function (t) {
+    t.plan(2);
+
+    var obj = { x : { y : 2 }, a: 4 };
+
+    var expected = [[],["x"],["x","y"],["a"]];
+    var sync = traverse(obj).paths();
+    t.deepEqual(sync, expected);
+
+    traverseAsync(obj).paths(function (err, paths) {
+        t.deepEqual(paths, expected);
+    });
+});

--- a/test/async-reduce.js
+++ b/test/async-reduce.js
@@ -1,0 +1,15 @@
+var test = require('tape');
+var traverse = require('../').async;
+var deepEqual = require('./lib/deep_equal');
+var util = require('util');
+
+test('async reduce', function (t) {
+    t.plan(1);
+
+    var obj = { x : 3 };
+    traverse(obj).reduce(function (acc, x, cb) {
+        cb(null, acc + 1);
+    }, 0, function (err, acc) {
+        t.equal(acc, 1);
+    });
+});


### PR DESCRIPTION
This pull request adds asynchronous implementations of most core traverse methods (`map`, `forEach`, `reduce`, etc.). This is available as `traverse.async`. This functionality is especially useful for traversing an object with in-place updates that require asynchronous processes, e.g. to expand a node in the tree by fetching more data from an API.

This is currently accomplished by including caolan's async library, though that dependency could be removed if preferred.

If this is too radical to include, then I can publish as a separate library. But asynchrony seems fundamental to modules in Node, and many others in this ecosystem provide both sync and async variants in the same module, e.g. Node core, glob, etc.
