### PR TITLE
Add method to delete element at specified path

### DIFF
--- a/index.js
+++ b/index.js
@@ -4,6 +4,7 @@ var traverse = module.exports = function (obj) {
 
 function Traverse (obj) {
     this.value = obj;
+    this.pathSeparator = '.'
 }
 
 Traverse.prototype.get = function (ps) {
@@ -28,6 +29,22 @@ Traverse.prototype.has = function (ps) {
         }
         node = node[key];
     }
+    return true;
+};
+
+Traverse.prototype.delete = function (ps) {
+    var node = this.value;
+    if (typeof ps === 'string') { 
+        ps = ps.split(this.pathSeparator)
+    }
+    for (var i = 0; i < ps.length - 1; i ++) {
+        var key = ps[i];
+        if (!node || !hasOwnProperty.call(node, key)) {
+            return false;
+        }
+        node = node[key];
+    }
+    delete node[ps[i]];
     return true;
 };
 

--- a/readme.markdown
+++ b/readme.markdown
@@ -122,6 +122,10 @@ Set the element at the array `path` to `value`.
 
 Return whether the element at the array `path` exists.
 
+## .delete(path)
+
+Delete the element at the array `path`.
+
 # context
 
 Each method that takes a callback has a context (its `this` object) with these


### PR DESCRIPTION
This PR adds a method to `delete` an element at a specified path array, in addition to `get/set/has`.
The path argument supports a string based path introduced with #46.